### PR TITLE
Align profile API integration with backend

### DIFF
--- a/goyo_app/lib/data/services/api_service.dart
+++ b/goyo_app/lib/data/services/api_service.dart
@@ -121,11 +121,35 @@ extension AuthApi on ApiService {
 
 extension ProfileApi on ApiService {
   Future<UserProfile> getMe() async {
-    final res = await _dio.get('/api/profile'); // 서버 스펙에 맞춰 수정
-    return UserProfile.fromJson(res.data as Map<String, dynamic>);
+    try {
+      final res = await _dio.get('/api/profile/');
+      final data = res.data;
+      if (data is! Map<String, dynamic>) {
+        throw const FormatException('Invalid profile payload');
+      }
+      return UserProfile.fromJson(data);
+    } on DioException catch (e) {
+      final code = e.response?.statusCode;
+      final msg = _pretty(e.response?.data) ?? e.message ?? 'Failed to load profile';
+      throw Exception('Profile fetch failed ($code): $msg');
+    }
   }
 
-  Future<void> updateProfile({required String name}) async {
-    await _dio.put('/api/profile', data: {'name': name});
+  Future<UserProfile> updateProfile({required String name}) async {
+    try {
+      final res = await _dio.put(
+        '/api/profile/',
+        data: {'name': name},
+      );
+      final data = res.data;
+      if (data is! Map<String, dynamic>) {
+        throw const FormatException('Invalid profile payload');
+      }
+      return UserProfile.fromJson(data);
+    } on DioException catch (e) {
+      final code = e.response?.statusCode;
+      final msg = _pretty(e.response?.data) ?? e.message ?? 'Failed to update profile';
+      throw Exception('Profile update failed ($code): $msg');
+    }
   }
 }

--- a/goyo_app/lib/features/auth/auth_provider.dart
+++ b/goyo_app/lib/features/auth/auth_provider.dart
@@ -4,27 +4,37 @@ import 'package:goyo_app/data/services/api_service.dart';
 import 'package:goyo_app/core/auth/token_manager.dart';
 
 class UserProfile {
+  final int id;
   final String email;
   final String name;
-  final String? phone;
-  final bool isVerified;
-  final bool isActive;
+  final bool ancEnabled;
+  final int suppressionLevel;
+  final DateTime? createdAt;
 
-  UserProfile({
+  const UserProfile({
+    required this.id,
     required this.email,
     required this.name,
-    this.phone,
-    required this.isVerified,
-    required this.isActive,
+    required this.ancEnabled,
+    required this.suppressionLevel,
+    this.createdAt,
   });
 
-  factory UserProfile.fromJson(Map<String, dynamic> j) => UserProfile(
-    email: j['email'] as String,
-    name: (j['name'] ?? '') as String,
-    phone: j['phone'] as String?,
-    isVerified: (j['is_verified'] ?? false) as bool,
-    isActive: (j['is_active'] ?? false) as bool,
-  );
+  factory UserProfile.fromJson(Map<String, dynamic> j) {
+    final created = j['created_at'];
+    return UserProfile(
+      id: (j['id'] as num).toInt(),
+      email: j['email'] as String,
+      name: (j['name'] ?? '') as String,
+      ancEnabled: (j['anc_enabled'] ?? false) as bool,
+      suppressionLevel: (j['suppression_level'] as num? ?? 0).toInt(),
+      createdAt: created is String
+          ? DateTime.tryParse(created)
+          : created is DateTime
+              ? created
+              : null,
+    );
+  }
 }
 
 class AuthProvider extends ChangeNotifier {
@@ -33,10 +43,16 @@ class AuthProvider extends ChangeNotifier {
 
   String? _accessToken;
   UserProfile? _me;
+  bool _profileLoading = false;
+  bool _profileUpdating = false;
+  String? _profileError;
   bool _bootstrapped = false;
 
   String? get token => _accessToken;
   UserProfile? get me => _me;
+  bool get profileLoading => _profileLoading;
+  bool get profileUpdating => _profileUpdating;
+  String? get profileError => _profileError;
   bool get isLoggedIn => _accessToken != null && _me != null;
   bool get bootstrapped => _bootstrapped;
 
@@ -45,7 +61,11 @@ class AuthProvider extends ChangeNotifier {
     try {
       _accessToken = await TokenManager.getToken();
       if (_accessToken != null && _accessToken!.isNotEmpty) {
-        await loadMe();
+        try {
+          await loadMe();
+        } catch (_) {
+          // 에러는 profileError에 저장되므로 무시하고 부트스트랩 완료
+        }
       }
     } finally {
       _bootstrapped = true;
@@ -74,22 +94,48 @@ class AuthProvider extends ChangeNotifier {
     } catch (_) {}
     _accessToken = null;
     _me = null;
+    _profileError = null;
+    _profileLoading = false;
+    _profileUpdating = false;
     await TokenManager.clearToken();
     notifyListeners();
   }
 
   /// 내 프로필 가져오기
   Future<void> loadMe() async {
-    final data = await api.getMe(); // ApiService에 구현 필요(아래 참고)
-    _me = data;
+    _profileLoading = true;
+    _profileError = null;
     notifyListeners();
+
+    try {
+      final data = await api.getMe(); // ApiService에 구현 필요(아래 참고)
+      _me = data;
+    } catch (e) {
+      _profileError = e.toString();
+      rethrow;
+    } finally {
+      _profileLoading = false;
+      notifyListeners();
+    }
   }
 
   /// 이름 변경 후 다시 로드(또는 로컬 반영)
   Future<void> updateMyName(String newName) async {
     final n = newName.trim();
     if (n.isEmpty) return;
-    await api.updateProfile(name: n); // ApiService에 구현 필요
-    await loadMe();
+    _profileUpdating = true;
+    _profileError = null;
+    notifyListeners();
+
+    try {
+      final data = await api.updateProfile(name: n); // ApiService에 구현 필요
+      _me = data;
+    } catch (e) {
+      _profileError = e.toString();
+      rethrow;
+    } finally {
+      _profileUpdating = false;
+      notifyListeners();
+    }
   }
 }

--- a/goyo_app/lib/ui/profile/profile_page.dart
+++ b/goyo_app/lib/ui/profile/profile_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:goyo_app/features/anc/anc_store.dart';
+import 'package:goyo_app/features/auth/auth_provider.dart';
 
 class ProfilePage extends StatefulWidget {
   const ProfilePage({super.key});
@@ -11,13 +12,21 @@ class ProfilePage extends StatefulWidget {
 
 class _ProfilePageState extends State<ProfilePage> {
   final nameCtrl = TextEditingController();
-  bool saving = false;
+  String? _lastLoadedName;
 
   @override
   void initState() {
     super.initState();
     final store = context.read<AncStore>();
     nameCtrl.text = store.userName;
+    _lastLoadedName = store.userName;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final profileName = context.read<AuthProvider>().me?.name;
+      if (profileName != null && profileName.isNotEmpty) {
+        _syncController(profileName);
+      }
+    });
   }
 
   @override
@@ -29,6 +38,60 @@ class _ProfilePageState extends State<ProfilePage> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final auth = context.watch<AuthProvider>();
+    final profile = auth.me;
+
+    if (auth.profileLoading && profile == null) {
+      return const Scaffold(
+        body: SafeArea(
+          child: Center(child: CircularProgressIndicator()),
+        ),
+      );
+    }
+
+    if (auth.profileError != null && profile == null) {
+      return Scaffold(
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const Icon(Icons.error_outline, size: 48, color: Colors.redAccent),
+                const SizedBox(height: 16),
+                Text(
+                  '프로필 정보를 불러오지 못했습니다.',
+                  style: Theme.of(context).textTheme.titleMedium,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  auth.profileError!,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyMedium
+                      ?.copyWith(color: cs.error),
+                ),
+                const SizedBox(height: 24),
+                FilledButton(
+                  onPressed: auth.profileLoading
+                      ? null
+                      : () => context.read<AuthProvider>().loadMe(),
+                  child: const Text('다시 시도'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (profile?.name != null && profile!.name != _lastLoadedName) {
+      _syncController(profile.name);
+    }
+
     final anc = context.watch<AncStore>();
     final current = anc.mode;
 
@@ -37,6 +100,33 @@ class _ProfilePageState extends State<ProfilePage> {
         child: ListView(
           padding: const EdgeInsets.all(16),
           children: [
+            if (auth.profileError != null)
+              Card(
+                color: cs.errorContainer,
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Row(
+                    children: [
+                      Icon(Icons.error_outline, color: cs.onErrorContainer),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          auth.profileError!,
+                          style: TextStyle(color: cs.onErrorContainer),
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: auth.profileLoading
+                            ? null
+                            : () => context.read<AuthProvider>().loadMe(),
+                        child: const Text('새로고침'),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            if (auth.profileError != null) const SizedBox(height: 12),
+
             // ── User info ─────────────────────────────────────────────
             Card(
               child: Padding(
@@ -57,6 +147,7 @@ class _ProfilePageState extends State<ProfilePage> {
                           hintText: 'Enter your display name',
                           prefixIcon: Icon(Icons.badge_outlined),
                         ),
+                        enabled: !auth.profileUpdating,
                       ),
                     ),
                   ],
@@ -162,10 +253,10 @@ class _ProfilePageState extends State<ProfilePage> {
             ),
             const SizedBox(height: 16),
 
-            // ── Save changes ─────────────────────────────────────────
+            // ── Save changes ────────────────────────────────────────
             FilledButton(
-              onPressed: saving ? null : _save,
-              child: saving
+              onPressed: auth.profileUpdating ? null : _save,
+              child: auth.profileUpdating
                   ? const SizedBox(
                       width: 22,
                       height: 22,
@@ -189,19 +280,34 @@ class _ProfilePageState extends State<ProfilePage> {
   }
 
   Future<void> _save() async {
-    setState(() => saving = true);
-    final store = context.read<AncStore>();
+    final auth = context.read<AuthProvider>();
+    final trimmed = nameCtrl.text.trim();
+    if (trimmed.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('이름을 입력해 주세요.')),
+      );
+      return;
+    }
 
-    // 1) 이름 저장 (백엔드 연동 지점)
-    await store.updateUserName(nameCtrl.text);
+    try {
+      await auth.updateMyName(trimmed);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Profile updated successfully')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('이름 변경에 실패했어요: $e')),
+      );
+    }
+  }
 
-    // 2) 모드/프리셋 저장 필요 시 여기서 API 호출 추가
-    // await api.saveAncPreset(mode: store.mode, auto: store.auto, intensity: store.intensity);
-
-    if (!mounted) return;
-    setState(() => saving = false);
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Profile updated successfully')),
+  void _syncController(String name) {
+    _lastLoadedName = name;
+    nameCtrl.value = TextEditingValue(
+      text: name,
+      selection: TextSelection.collapsed(offset: name.length),
     );
   }
 }


### PR DESCRIPTION
## Summary
- align the profile service endpoints with the backend contract and deserialize the response payloads
- update the auth provider profile model to match the server fields and expose loading/updating/error state
- refresh the profile page to consume the auth provider, show status feedback, and handle name updates via the API

## Testing
- flutter test *(fails: Flutter SDK is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912e2fb5b748322bf882e2e1828fdd4)